### PR TITLE
[Issue #36] Switching the shuffle function code to a Fisher–Yates shuffle

### DIFF
--- a/src/app/random.service.ts
+++ b/src/app/random.service.ts
@@ -429,7 +429,16 @@ shovelKnight
    * @param array array to shuffle
    */
   shuffle(array) {
-    array.sort(() => Math.random() - 0.5);
+    // https://stackoverflow.com/a/2450976
+    var currentIndex = array.length, randomIndex
+
+    while (0 !== currentIndex) {
+      randomIndex = Math.floor(Math.random() * currentIndex)
+      currentIndex--
+      [array[currentIndex], array[randomIndex]] = [
+        array[randomIndex], array[currentIndex]]
+    }
+    return array
   }
 
   /**


### PR DESCRIPTION
Code from a Stack Overflow post, but this algorithm should remove Firefox specific weirdness with the randomness of the site.

Here is some data from Firefox and Chrome, showing the old algorithm (which was working for Chrome but not Firefox) to highlight the difference this algorithm makes with Firefox. You can see in the `firefox_old.csv` dataset, the shuffled characters are biased towards the original order of the characters.

Column 1 is the "run", col 2 is the character id with col 3 being the character name:

[firefox_old.csv](https://github.com/snapish/Multiman/files/6681070/firefox_old.csv)
[chrome_old.csv](https://github.com/snapish/Multiman/files/6681071/chrome_old.csv)
[firefox_new.csv](https://github.com/snapish/Multiman/files/6681072/firefox_new.csv)
[chrome_new.csv](https://github.com/snapish/Multiman/files/6681073/chrome_new.csv)

